### PR TITLE
Bind empty string instead of "null" when onceText's value === null.

### DIFF
--- a/once.js
+++ b/once.js
@@ -47,7 +47,7 @@
     {
       name: 'onceText',
       binding: function (element, value) {
-        element.text(value);
+        element.text(value !== null ? value : "");
       }
     },
     {


### PR DESCRIPTION
From the usability perspective, empty string is a better indicator of missing value than "null" string. In most use-cases IMHO this is desired behavior. The "null" string might seem like an error to the end-user.
