### PR TITLE
Add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/tadeuszwojcik/angular-once.git"
-  }
+  },
+  "main": "once.js"
 }


### PR DESCRIPTION
Add "main" entrypoint for require-style compatibility.

node/browserify `require` looks for `angular-once/index.js` by default. "main" allows you to specify where the module's entrypoint is.
