### PR TITLE
Support "for" attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ List below contains comparison of angular-once directives ( **one time bindings*
 | `once-alt="value"`     | `ng-attr-alt` |`<img once-alt="user.name" />`|
 | `once-id="value"`     | `ng-attr-id` |`<ANY once-id="user.name" /></ANY>`|
 | `once-for="value"`     | `N/A` |`<ANY once-for="'fname_' + item.uuid" /></ANY>`|
-| `once-placeholder="value"`     | `N/A` |`<ANY once-placeholder="field.placeholder" /></ANY>`|
 | `once-if="condition"`     | `ng-if` |`<ANY once-if="user.isAdmin" /></ANY>`|
 | `once-class="name:cond"`     | `ng-class` |`<ANY once-class="{'p': user.admin}" /></ANY>`|
 | `once-style="value"`     | `ng-style` |`<ANY once-style="{color:blue}" /></ANY>`|

--- a/once.js
+++ b/once.js
@@ -100,12 +100,6 @@
       }
     },
     {
-      name: 'oncePlaceholder',
-      binding: function (element, value) {
-        element.attr('placeholder', value);
-      }
-    },
-    {
       name: 'onceIf',
       binding: function (element, value) {
         if (!value) {


### PR DESCRIPTION
I know angular doesn't have an equivalent, but often when creating forms with generated checkboxes/radio buttons I find myself needing to match onceId with a onceFor.
